### PR TITLE
Add option for local (fine-tuned) model

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,8 @@ time: 1
 # model_configs:
 #   mail_user: null@null.null
 #   my_hf_home: /scratch/gpfs/<netid>/.cache/huggingface # If set, you can use `echo $HF_HOME`
+#   # my_local_model will overwrite the "serve" parameter to vllm with a local model; required if not using a cached HF model
+#   my_local_model: /scratch/gpfs/<netid>/path/to/your/model 
 
 # to run bigger models we will require to use the pli cluster
 use_pli: True # set to True if you want to use the pli cluster

--- a/templates/slurm_template.txt
+++ b/templates/slurm_template.txt
@@ -23,7 +23,7 @@ export HF_HOME={{ my_hf_home }}
 FREE_PORT=$(get_free_port)
 
 # Start vllm serve
-vllm serve {{ serve }} --tensor-parallel-size {{ tensor_parallel_size }} --quantization {{ quantization }}
+vllm serve {{ my_local_model or serve }} --tensor-parallel-size {{ tensor_parallel_size }} --quantization {{ quantization }}
 
 # Wait for the server to start (adjust sleep time if needed)
 sleep 10


### PR DESCRIPTION
Added `my_local_model` which can override the HuggingFace cached model option when running vllm serve; our team will need this for fine-tuned models